### PR TITLE
Add objective-based early-termination condition

### DIFF
--- a/examples/cnot1-objthreshold-setup.jl
+++ b/examples/cnot1-objthreshold-setup.jl
@@ -107,8 +107,8 @@ vtarget = rot1*utarget
 
 params = Juqbox.objparams([N], [Nguard], T, nsteps, Uinit=U0, Utarget=vtarget, Cfreq=om, Rfreq=rot_freq,
                           Hconst=H0, Hsym_ops=Hsym_ops, Hanti_ops=Hanti_ops)
-
-# initial parameter guess
+# terminate if objective function is below this value
+params.objThreshold = 1e-3
 
 # D1 smaller than 5 does not work
 D1 = 10 # Number of B-spline coefficients per segment

--- a/examples/cnot1-setup.jl
+++ b/examples/cnot1-setup.jl
@@ -108,7 +108,8 @@ vtarget = rot1*utarget
 params = Juqbox.objparams([N], [Nguard], T, nsteps, Uinit=U0, Utarget=vtarget, Cfreq=om, Rfreq=rot_freq,
                           Hconst=H0, Hsym_ops=Hsym_ops, Hanti_ops=Hanti_ops)
 
-# initial parameter guess
+# optionally: terminate optimization early if objective function falls below this value
+params.objThreshold = 0 #1e-3
 
 # D1 smaller than 5 does not work
 D1 = 10 # Number of B-spline coefficients per segment

--- a/src/evalobjgrad.jl
+++ b/src/evalobjgrad.jl
@@ -114,6 +114,7 @@ mutable struct objparams
     #Linear solver object to solve linear system in timestepping
     linear_solver ::lsolver_object
 
+    objThreshold :: Float64
     traceInfidelityThreshold :: Float64
     lastTraceInfidelity :: Float64
     lastLeakIntegral :: Float64    
@@ -230,6 +231,7 @@ mutable struct objparams
 
         quiet = false
 
+        objThreshold = 0.0
         traceInfidelityThreshold = 0.0
         usingPriorCoeffs = false
         priorCoeffs = [] # zeros(0)
@@ -290,7 +292,7 @@ mutable struct objparams
              objFuncType,leak_lbound,leak_ubound,
              0.0,0.0,zeros(0),zeros(0),zeros(0),saveConvHist,
              zeros(0), zeros(0), zeros(0), zeros(0), 
-             linear_solver, traceInfidelityThreshold, 0.0, 0.0, usingPriorCoeffs,
+             linear_solver, objThreshold, traceInfidelityThreshold, 0.0, 0.0, usingPriorCoeffs,
              priorCoeffs, quiet, Rfreq, false, []
             )
 

--- a/src/evalobjgrad.jl
+++ b/src/evalobjgrad.jl
@@ -292,8 +292,8 @@ mutable struct objparams
              objFuncType,leak_lbound,leak_ubound,
              0.0,0.0,zeros(0),zeros(0),zeros(0),saveConvHist,
              zeros(0), zeros(0), zeros(0), zeros(0), 
-             linear_solver, objThreshold, traceInfidelityThreshold, 0.0, 0.0, usingPriorCoeffs,
-             priorCoeffs, quiet, Rfreq, false, []
+             linear_solver, objThreshold, traceInfidelityThreshold, 0.0, 0.0, 
+             usingPriorCoeffs, priorCoeffs, quiet, Rfreq, false, []
             )
 
     end

--- a/src/ipopt_interface.jl
+++ b/src/ipopt_interface.jl
@@ -226,7 +226,11 @@ function intermediate_par(
         push!(params.primaryHist, params.lastTraceInfidelity)
         push!(params.secondaryHist,  params.lastLeakIntegral)
     end
-    if params.lastTraceInfidelity < params.traceInfidelityThreshold
+    if obj_value < params.objThreshold
+        println("Stopping because objective value = ", obj_value,
+                " < threshold = ", params.objThreshold)        
+        return false
+    elseif params.lastTraceInfidelity < params.traceInfidelityThreshold
         println("Stopping because trace infidelity = ", params.lastTraceInfidelity,
                 " < threshold = ", params.traceInfidelityThreshold)        
         return false


### PR DESCRIPTION
Add the parameter `params.objThreshold`, which acts similarly to `params.traceInfidelityThreshold` but for total objective value instead of just infidelity.