### PR TITLE
Fixed missing reference to linear_solver

### DIFF
--- a/src/evalobjgrad.jl
+++ b/src/evalobjgrad.jl
@@ -1896,6 +1896,8 @@ function eval_forward(U0::Array{Float64,2}, pcof0::Array{Float64,1}, params::obj
     Nfreq = params.Nfreq
     Nsig = 2*Ncoupled + Nunc
 
+    linear_solver = params.linear_solver    
+
     Psize = size(pcof,1) #must provide separate coefficients for the real and imaginary parts of the control fcn
     if Psize%2 != 0 || Psize < 6
         error("pcof must have an even number of elements >= 6, not ", Psize)


### PR DESCRIPTION
In file `src/evalobjgrad.jl`, function `eval_forward`, line 1982 made reference to missing object `linear_solver`, which is not created anywhere in the function (and is not a global variable), causing an error at runtime. The similar function `traceobjgrad` contains the line `linear_solver = params.linear_solver`, so I copied that line into `eval_forward` (in a similar position).

After making the change, I no longer get a runtime error when running `eval_forward`. 