### PR TITLE
Initialize working arrays inside params constructor.

### DIFF
--- a/src/evalobjgrad.jl
+++ b/src/evalobjgrad.jl
@@ -248,7 +248,7 @@ mutable struct objparams
                        objFuncType:: Int64 = 1, leak_ubound:: Float64=1.0e-3,
                        wmatScale::Float64 = 1.0, use_sparse::Bool = false, use_custom_forbidden::Bool = false,
                        linear_solver::lsolver_object = lsolver_object(nrhs=prod(Ne)), msb_order::Bool = true,
-                       dVds::Array{ComplexF64,2}= Array{ComplexF64}(undef,0,0))
+                       dVds::Array{ComplexF64,2}= Array{ComplexF64}(undef,0,0), nCoeff::Int = 1)
         pFidType = 2
         Nosc   = length(Ne) # number of subsystems
         N      = prod(Ne)
@@ -283,7 +283,7 @@ mutable struct objparams
                 end
             end
         else
-            isSymm = []
+            isSymm = BitArray(undef, Nunc)
         end
         
         # Set default Tikhonov parameter
@@ -406,6 +406,9 @@ mutable struct objparams
             my_sv_type = 2
         end
 
+        wa = working_arrays(N, Ntot, convert(MyRealMatrix, Hconst), convert(Vector{MyRealMatrix}, Hsym_ops1), convert(Vector{MyRealMatrix}, Hanti_ops1), convert(Vector{MyRealMatrix}, Hunc_ops1), isSymm, pFidType, objFuncType, nCoeff)
+
+
         # sv_type is used for continuation. Only change this if you know what you are doing
         new(
              Nosc, N, Nguard, Ne, Ng, Ne+Ng, T, nsteps, Uinit, real(Utarget), imag(Utarget), 
@@ -417,7 +420,7 @@ mutable struct objparams
              zeros(0), zeros(0), zeros(0), zeros(0), 
              linear_solver, objThreshold, traceInfidelityThreshold, 0.0, 0.0, 
              usingPriorCoeffs, priorCoeffs, quiet, Rfreq, false, [],
-             real(my_dVds), imag(my_dVds), my_sv_type
+             real(my_dVds), imag(my_dVds), my_sv_type, wa
             )
 
     end

--- a/src/ipopt_interface.jl
+++ b/src/ipopt_interface.jl
@@ -262,9 +262,6 @@ where the fundamental frequency is random.
 """
 function ipopt_setup(params:: Juqbox.objparams, nCoeff:: Int64, maxAmp:: Matrix{Float64}; zeroCtrlBC::Bool = true, maxIter:: Int64=50, lbfgsMax:: Int64=200, coldStart:: Bool=true, ipTol:: Float64=1e-5, acceptTol:: Float64=1e-5, acceptIter:: Int64=15, nodes::AbstractArray=[0.0], weights::AbstractArray=[1.0])
 
-    # setup the working_arrays object, holding temporary arrays
-    params.wa = working_arrays(params.N, params.N+params.Nguard, params.Hconst, params.Hsym_ops, params.Hanti_ops, params.Hunc_ops, params.isSymm, params.pFidType, params.objFuncType, nCoeff)
-    
     minCoeff, maxCoeff = control_bounds(params, maxAmp, nCoeff, zeroCtrlBC)
 
     #Initialize the last fidelity and leak terms and gradients


### PR DESCRIPTION
Previously, the working arrays were initialized only during IpOpt setup (i.e. when run_optimizer is called). However they might be needed without the call to run_optimizer, e.g. when plot_results is called on the initial pcof0 vector. Hence, initializing them inside the params constructor ensures that they are always availble.

Note: This pull request changes the interface for constructing the params struct (::objparams): the constructor needs to know the length of the pcof vector, hence 'nCoeff' should be passed to the constructor. 